### PR TITLE
fix: edit default variable

### DIFF
--- a/application.yml
+++ b/application.yml
@@ -5,7 +5,7 @@ eureka:
     fetch-registry: true
     register-with-eureka: true
     service-url:
-      defaultZone: ${EUREKA_SERVER_ADDRESS:#{'http://localhost:8761/eureka'}}
+      defaultZone: ${EUREKA_SERVER_ADDRESS:#{'http://localhost:8080/eureka'}}
       
 spring:
   zipkin:

--- a/application.yml
+++ b/application.yml
@@ -5,7 +5,7 @@ eureka:
     fetch-registry: true
     register-with-eureka: true
     service-url:
-      defaultZone: ${EUREKA_SERVER_ADDRESS:http://localhost:8761/eureka}
+      defaultZone: ${EUREKA_SERVER_ADDRESS:#{'http://localhost:8761/eureka'}}
       
 spring:
   zipkin:


### PR DESCRIPTION
If your default value contains any colons (like DB connection string or http ur), the default value has to be quoted.

[Providing environment variables default values via Spring application.yaml](https://dev.kuffel.io/env-variables-spring-default/)